### PR TITLE
fix: improve cache handling and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ QAMini is a streamlined version of the QAAPP, containing only the core features 
 
 1. **Clone and setup:**
 ```bash
-cd qamini
+cd qa-app
 pnpm install
 ```
 

--- a/apps/web/__tests__/wallet-connect.ui.spec.tsx
+++ b/apps/web/__tests__/wallet-connect.ui.spec.tsx
@@ -18,4 +18,18 @@ describe('WalletConnect UI (disconnected)', () => {
     expect(screen.getAllByText('连接钱包').length).toBeGreaterThan(0);
     expect(screen.getByRole('button', { name: '连接钱包' })).toBeInTheDocument();
   });
+
+  it('calls onConnect when button is clicked', () => {
+    const handleConnect = jest.fn();
+    render(
+      <WalletConnect
+        isConnected={false}
+        loading={false}
+        onConnect={handleConnect}
+      />
+    );
+
+    screen.getByRole('button', { name: '连接钱包' }).click();
+    expect(handleConnect).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/web/lib/data-cache.ts
+++ b/apps/web/lib/data-cache.ts
@@ -99,8 +99,9 @@ class DataCacheManager {
         if (this.isEntryValid(entry)) {
           this.stats.hitRate = this.calculateHitRate(true);
           return entry.compressed ? this.decompress(entry.data as string) : (entry.data as T);
-        }
+        } else {
           this.memoryCache.delete(key);
+        }
       }
 
       // 2. 检查LocalStorage缓存
@@ -115,8 +116,9 @@ class DataCacheManager {
               this.memoryCache.set(key, entry);
               this.stats.hitRate = this.calculateHitRate(true);
               return entry.compressed ? this.decompress(entry.data as string) : (entry.data as T);
-            }
+            } else {
               localStorage.removeItem(`cache_${key}`);
+            }
           } catch {
             localStorage.removeItem(`cache_${key}`);
           }

--- a/packages/contracts/scripts/fix-tests.ts
+++ b/packages/contracts/scripts/fix-tests.ts
@@ -95,7 +95,7 @@ async function main() {
             console.log(`    ✅ ${parsedLog.name} event: ${parsedLog.args.length} arguments`);
           }
         } catch (e2) {
-          // Ignore unparseable logs
+          // Ignore unparsable logs
         }
       }
     }


### PR DESCRIPTION
## Summary
- fix cache invalidation logic in web data cache
- improve WalletConnect UI test coverage
- correct installation path and typo in contracts script

## Testing
- `pnpm --filter @qa-app/web lint`
- `pnpm --filter @qa-app/web type-check`
- `pnpm --filter @qa-app/web test`
- `pnpm --filter @qa-app/contracts test`
- `pnpm --filter @qa-app/contracts lint` *(fails: None of the selected packages has a "lint" script)*
- `pnpm --filter @qa-app/contracts type-check` *(fails: None of the selected packages has a "type-check" script)*

------
https://chatgpt.com/codex/tasks/task_e_68bde122a85c832f99c689d0e25fbb5c